### PR TITLE
fix: ajout de check quand on vérifie le statut d'un service

### DIFF
--- a/Service/CircuitBreakerService.php
+++ b/Service/CircuitBreakerService.php
@@ -82,7 +82,7 @@ class CircuitBreakerService
             $this->status[$service] = self::OPEN;
         }
 
-        return $this->status[$service] === self::OPEN;
+        return isset($this->status[$service]) && $this->status[$service] === self::OPEN;
     }
 
     /**


### PR DESCRIPTION
# Description

Dans le cadre de la mise en place des services du suivi d'actu sur le BFF AEC, on a besoin d'utiliser plusieurs services en même temps et donc aussi plusieurs fois le circuit breaker. On est tombé sur le cas où on avait une NOTICE quand on on vérifiait si le circuit d'un service était ouvert ou fermé.

Plus précisément, il semble que la fonction qui permet de vérifier le statut d'un service regarde dans une variable qui n'est pas forcément initialisée. Cette initialisation peut arriver après la vérification car elle se passe lorsque l'on fait la requête au service et que l'on a besoin de vérifier l'état du service AVANT de faire une requête.

On ajoute donc un check sur la variable avant de tester sa valeur.

# Recette

Utiliser le circuit breaker avant l'appel à un service et vérifier qu'il est bien fermé.