### PR TITLE
fix/cache-adapter(symfony-update): utilise l'interface du cache adapter

### DIFF
--- a/Service/CircuitBreakerService.php
+++ b/Service/CircuitBreakerService.php
@@ -4,7 +4,7 @@ namespace CircuitBreakerBundle\Service;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait as PsrLoggerTrait;
-use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 
 class CircuitBreakerService
 {
@@ -18,7 +18,7 @@ class CircuitBreakerService
     const STATUS_DOWN = false;
 
     /**
-     * @var AbstractAdapter
+     * @var AdapterInterface
      */
     private $cacheApp;
 
@@ -38,11 +38,11 @@ class CircuitBreakerService
     private $timeout;
 
     /**
-     * @param AbstractAdapter $cacheApp
+     * @param AdapterInterface $cacheApp
      * @param int $threshold
      * @param int $timeout
      */
-    public function __construct(AbstractAdapter $cacheApp, int $threshold, int $timeout)
+    public function __construct(AdapterInterface $cacheApp, int $threshold, int $timeout)
     {
         $this->cacheApp = $cacheApp;
         $this->threshold = $threshold;

--- a/Tests/Service/CircuitBreakerServiceTest.php
+++ b/Tests/Service/CircuitBreakerServiceTest.php
@@ -8,7 +8,7 @@ class CircuitBreakerServiceTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->mockCacheApp = $this->getMockBuilder('Symfony\Component\Cache\Adapter\AbstractAdapter')
+        $this->mockCacheApp = $this->getMockBuilder('Symfony\Component\Cache\Adapter\AdapterInterface')
             ->disableOriginalConstructor()
             ->setMethods(['getItem', 'save', 'doHave', 'doFetch', 'doClear', 'doSave', 'doDelete'])
             ->getMock();


### PR DESCRIPTION
# Description
En raison du fait que Symfony 3.3 trace désormais dans le profiler le cache, il injecte en environnement de développement une instance de TraceableAdapter.

Celle-ci en revanche n'hérite pas de AbstractAdapter mais tous les adapter implémente AdapterInterface.

Il faut donc désarmait attendre une AdapterInterface pour être entièrement compatible.

Ce code reste compatible avec la version 3.2 bien entendu :)

# Spécification technique
1. Remplacement du typehint de `AbstractAdapter` vers `AdapterInterface`
2. Mise à jour des tests

# Recette
Aucune, elle se fera sur les BFF (le code étant couvert par les tests)

# Dépendances
Aucune